### PR TITLE
Add options to export packed scss files and images to your project

### DIFF
--- a/lib/texture_packer.rb
+++ b/lib/texture_packer.rb
@@ -5,6 +5,7 @@ class TexturePacker
   attr_reader :base_dir_name
   attr_reader :dir_without_theme
   attr_reader :output_paths_mapping
+  attr_reader :has_mobile
 
   def initialize(dir_name, output_paths_mapping, content, has_mobile)
     @output_paths_mapping = output_paths_mapping

--- a/lib/texture_packer.rb
+++ b/lib/texture_packer.rb
@@ -4,6 +4,7 @@ class TexturePacker
   attr_reader :dir_name
   attr_reader :base_dir_name
   attr_reader :dir_without_theme
+  attr_reader :output_paths_mapping
 
   def initialize(dir_name, output_paths_mapping, content, has_mobile)
     @output_paths_mapping = output_paths_mapping

--- a/lib/texture_packer.rb
+++ b/lib/texture_packer.rb
@@ -1,6 +1,7 @@
 require 'texture_packer/version'
 
 class TexturePacker
+  attr_reader :dir_name
   attr_reader :base_dir_name
   attr_reader :dir_without_theme
 

--- a/lib/texture_packer/cli.rb
+++ b/lib/texture_packer/cli.rb
@@ -65,7 +65,6 @@ class TexturePacker::Cli
     write_to_file(css_path.join('ocean.scss'), "#{css_pre_lines.join("\n")}\n\n#{output2}")
     packer.output_paths_mapping.each do |_, path|
       FileUtils.cp("#{path}-fs8.png", img_path.join("#{path.sub('packed', packer.base_dir_name)}.png"))
-      exec_cmd('pngquant', "#{path}.png", '--force')
     end
   end
 

--- a/lib/texture_packer/cli.rb
+++ b/lib/texture_packer/cli.rb
@@ -45,13 +45,15 @@ class TexturePacker::Cli
     # ----------------------------------------------------------------
     # ● 自動輸出到專案
     # ----------------------------------------------------------------
-    if project_dir
+    if @options.proejct_dir
       css_pre_lines = ["@import './mixin.scss';"]
       css_pre_lines.unshift("@import 'global_mixins';") if has_mobile
 
       sub_dirs = dir_name.split(File::Separator)[0...-1]
-      css_path = Pathname.new(project_dir).join('app', 'assets', 'stylesheets', 'packed_sprites', *sub_dirs, packer.dir_without_theme)
-      img_path = Pathname.new(project_dir).join('app', 'assets', 'images', *sub_dirs)
+
+      project_assets_path = Pathname.new(@options.project_dir).join('app', 'assets')
+      css_path = project_assets_path.join('stylesheets', 'packed_sprites', *sub_dirs, packer.dir_without_theme)
+      img_path = project_assets_path.join('images', *sub_dirs)
       FileUtils.mkdir_p(css_path)
       FileUtils.mkdir_p(img_path)
       write_to_file(css_path.join('mixin.scss'), output1)
@@ -65,8 +67,6 @@ class TexturePacker::Cli
 
   private
 
-  def project_dir
-  end
   def exec_cmd(*args)
     begin
       puts args.join(' ')

--- a/lib/texture_packer/cli.rb
+++ b/lib/texture_packer/cli.rb
@@ -45,27 +45,29 @@ class TexturePacker::Cli
     # ----------------------------------------------------------------
     # ● 自動輸出到專案
     # ----------------------------------------------------------------
-    if @options.project_dir
-      css_pre_lines = ["@import './mixin.scss';"]
-      css_pre_lines.unshift("@import 'global_mixins';") if has_mobile
-
-      sub_dirs = dir_name.split(File::Separator)[0...-1]
-
-      project_assets_path = Pathname.new(@options.project_dir).join('app', 'assets')
-      css_path = project_assets_path.join('stylesheets', 'packed_sprites', *sub_dirs, packer.dir_without_theme)
-      img_path = project_assets_path.join('images', *sub_dirs)
-      FileUtils.mkdir_p(css_path)
-      FileUtils.mkdir_p(img_path)
-      write_to_file(css_path.join('mixin.scss'), output1)
-      write_to_file(css_path.join('ocean.scss'), "#{css_pre_lines.join("\n")}\n\n#{output2}")
-      output_paths_mapping.each do |_, path|
-        FileUtils.cp("#{path}-fs8.png", img_path.join("#{path.sub('packed', packer.base_dir_name)}.png"))
-        exec_cmd('pngquant', "#{path}.png", '--force')
-      end
-    end
+    write_to_project_dir(packer, has_mobile) if @options.project_dir
   end
 
   private
+
+  def write_to_project_dir(packer, has_mobile)
+    css_pre_lines = ["@import './mixin.scss';"]
+    css_pre_lines.unshift("@import 'global_mixins';") if has_mobile
+
+    sub_dirs = packer.dir_name.split(File::Separator)[0...-1]
+
+    project_assets_path = Pathname.new(@options.project_dir).join('app', 'assets')
+    css_path = project_assets_path.join('stylesheets', 'packed_sprites', *sub_dirs, packer.dir_without_theme)
+    img_path = project_assets_path.join('images', *sub_dirs)
+    FileUtils.mkdir_p(css_path)
+    FileUtils.mkdir_p(img_path)
+    write_to_file(css_path.join('mixin.scss'), output1)
+    write_to_file(css_path.join('ocean.scss'), "#{css_pre_lines.join("\n")}\n\n#{output2}")
+    output_paths_mapping.each do |_, path|
+      FileUtils.cp("#{path}-fs8.png", img_path.join("#{path.sub('packed', packer.base_dir_name)}.png"))
+      exec_cmd('pngquant', "#{path}.png", '--force')
+    end
+  end
 
   def exec_cmd(*args)
     begin

--- a/lib/texture_packer/cli.rb
+++ b/lib/texture_packer/cli.rb
@@ -24,7 +24,6 @@ class TexturePacker::Cli
     compress_images! # 壓縮圖片
     write_to_file('packed.scss', output)
 
-
     write_to_project_dir!(packer, output1, output2) if @options.project_dir
   end
 

--- a/lib/texture_packer/cli.rb
+++ b/lib/texture_packer/cli.rb
@@ -45,7 +45,7 @@ class TexturePacker::Cli
     # ----------------------------------------------------------------
     # ● 自動輸出到專案
     # ----------------------------------------------------------------
-    if @options.proejct_dir
+    if @options.project_dir
       css_pre_lines = ["@import './mixin.scss';"]
       css_pre_lines.unshift("@import 'global_mixins';") if has_mobile
 

--- a/lib/texture_packer/cli.rb
+++ b/lib/texture_packer/cli.rb
@@ -1,4 +1,3 @@
-require 'yaml'
 require 'pathname'
 require 'fileutils'
 require 'texture_packer'
@@ -67,24 +66,7 @@ class TexturePacker::Cli
   private
 
   def project_dir
-    setting['project_dir']
   end
-
-  def setting
-    @setting ||= load_yaml('setting.yml')
-  end
-
-  # ----------------------------------------------------------------
-  # ● 載入 yaml
-  # ----------------------------------------------------------------
-  def load_yaml(path)
-    begin
-      return YAML.load_file(Pathname.new(__dir__).join(path)) || {}
-    rescue Errno::ENOENT
-      return {}
-    end
-  end
-
   def exec_cmd(*args)
     begin
       puts args.join(' ')

--- a/lib/texture_packer/cli.rb
+++ b/lib/texture_packer/cli.rb
@@ -45,12 +45,12 @@ class TexturePacker::Cli
     # ----------------------------------------------------------------
     # ● 自動輸出到專案
     # ----------------------------------------------------------------
-    write_to_project_dir(packer, has_mobile) if @options.project_dir
+    write_to_project_dir(packer, output1, output2, has_mobile) if @options.project_dir
   end
 
   private
 
-  def write_to_project_dir(packer, has_mobile)
+  def write_to_project_dir(packer, output1, output2, has_mobile)
     css_pre_lines = ["@import './mixin.scss';"]
     css_pre_lines.unshift("@import 'global_mixins';") if has_mobile
 
@@ -63,7 +63,7 @@ class TexturePacker::Cli
     FileUtils.mkdir_p(img_path)
     write_to_file(css_path.join('mixin.scss'), output1)
     write_to_file(css_path.join('ocean.scss'), "#{css_pre_lines.join("\n")}\n\n#{output2}")
-    output_paths_mapping.each do |_, path|
+    packer.output_paths_mapping.each do |_, path|
       FileUtils.cp("#{path}-fs8.png", img_path.join("#{path.sub('packed', packer.base_dir_name)}.png"))
       exec_cmd('pngquant', "#{path}.png", '--force')
     end

--- a/lib/texture_packer/cli/options.rb
+++ b/lib/texture_packer/cli/options.rb
@@ -2,6 +2,7 @@ require 'optparse'
 
 class TexturePacker::Cli::Options
   attr_reader :hook_run
+  attr_reader :proejct_dir
 
   def initialize(argv)
     OptionParser.new do |opts|
@@ -11,6 +12,10 @@ class TexturePacker::Cli::Options
 
       opts.on("-h", "--help", "Prints this help") do
         @hook_run = ->{ puts(opts) }
+      end
+
+      opts.on("-pPATH", "--project_dir=PATH", "Copy the generated scss files / images to specified project") do |val|
+        @proejct_dir = val
       end
     end.parse!(argv)
   end

--- a/lib/texture_packer/cli/options.rb
+++ b/lib/texture_packer/cli/options.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'optparse'
 
 class TexturePacker::Cli::Options
   attr_reader :hook_run
-  attr_reader :proejct_dir
+  attr_reader :project_dir
 
   def initialize(argv)
     OptionParser.new do |opts|
@@ -15,7 +17,7 @@ class TexturePacker::Cli::Options
       end
 
       opts.on("-pPATH", "--project_dir=PATH", "Copy the generated scss files / images to specified project") do |val|
-        @proejct_dir = val
+        @project_dir = val
       end
     end.parse!(argv)
   end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -20,6 +20,7 @@ class CliTest < Minitest::Test
       Usage: rake_test_loader [options]
           -v, --version                    show the version number
           -h, --help                       Prints this help
+          -p, --project_dir=PATH           Copy the generated scss files / images to specified project
     STRING
   end
 
@@ -28,6 +29,7 @@ class CliTest < Minitest::Test
       Usage: rake_test_loader [options]
           -v, --version                    show the version number
           -h, --help                       Prints this help
+          -p, --project_dir=PATH           Copy the generated scss files / images to specified project
     STRING
   end
 

--- a/test/copy_to_project_test.rb
+++ b/test/copy_to_project_test.rb
@@ -47,8 +47,17 @@ class CopyToProjectTest < Minitest::Test
   end
 
   def test_save
-    expect_to_receive(FileUtils, :mkdir_p, 'sdf', nil) do
-      @cli.send(:write_to_project_dir, @packer, false)
-    end
+    css_dir_path = Pathname.new('/var/www/my_project/app/assets/stylesheets/packed_sprites/side_menu')
+    img_dir_path = Pathname.new('/var/www/my_project/app/assets/images')
+
+    FileUtils.expects(:mkdir_p).with(css_dir_path)
+    FileUtils.expects(:mkdir_p).with(img_dir_path)
+
+    @cli.expects(:write_to_file).with(css_dir_path.join('mixin.scss'), 'content1')
+    @cli.expects(:write_to_file).with(css_dir_path.join('ocean.scss'), "@import './mixin.scss';\n\ncontent2")
+    FileUtils.expects(:cp).with('packed-fs8.png', img_dir_path.join('side_menu_ocean.png'))
+    @cli.expects(:exec_cmd).with('pngquant', 'packed.png', '--force')
+
+    @cli.send(:write_to_project_dir, @packer, 'content1', 'content2', false)
   end
 end

--- a/test/copy_to_project_test.rb
+++ b/test/copy_to_project_test.rb
@@ -56,7 +56,6 @@ class CopyToProjectTest < Minitest::Test
     @cli.expects(:write_to_file).with(css_dir_path.join('mixin.scss'), 'content1')
     @cli.expects(:write_to_file).with(css_dir_path.join('ocean.scss'), "@import './mixin.scss';\n\ncontent2")
     FileUtils.expects(:cp).with('packed-fs8.png', img_dir_path.join('side_menu_ocean.png'))
-    @cli.expects(:exec_cmd).with('pngquant', 'packed.png', '--force')
 
     @cli.send(:write_to_project_dir, @packer, 'content1', 'content2', false)
   end

--- a/test/copy_to_project_test.rb
+++ b/test/copy_to_project_test.rb
@@ -7,41 +7,7 @@ class CopyToProjectTest < Minitest::Test
     @cli = TexturePacker::Cli.new(['-p', '/var/www/my_project'])
 
     output_paths_mapping = { nil => 'packed' }
-    content = <<~STRING
-      /* ----------------------------------------------------
-         created with http://www.codeandweb.com/texturepacker 
-         ----------------------------------------------------
-         $TexturePacker:SmartUpdate:0e3cde37abc2d6283d832d64fcab33a3:c1d35c5361d7a9ec65c17d37456c5ef2:020bd24e3165ccf6122edbac54bb505b$
-         ----------------------------------------------------
-      
-         usage: <span class="{-spritename-} sprite"></span>
-      
-         replace {-spritename-} with the sprite you like to use
-      
-      */
-      
-      .sprite {display:inline-block; overflow:hidden; background-repeat: no-repeat;background-image:url(packed.png);}
-      
-      .arrow-in {width:50px; height:98px; background-position: -1px -101px}
-      .arrow-out {width:51px; height:98px; background-position: -1px -1px}
-      .frame {width:73px; height:74px; background-position: -147px -80px}
-      .icon_boss {width:71px; height:71px; background-position: -221px -1px}
-      .icon_boss:hover {width:71px; height:71px; background-position: -148px -1px}
-      .icon_contents {width:71px; height:71px; background-position: -294px -1px}
-      .icon_contents:hover {width:71px; height:71px; background-position: -222px -74px}
-      .icon_craft {width:57px; height:57px; background-position: -377px -74px}
-      .icon_craft:hover {width:57px; height:57px; background-position: -172px -156px}
-      .icon_mission {width:71px; height:71px; background-position: -295px -74px}
-      .icon_mission:hover {width:71px; height:71px; background-position: -231px -147px}
-      .panel_bottom {width:92px; height:77px; background-position: -53px -101px}
-      .panel_top {width:92px; height:77px; background-position: -54px -1px}
-      .shield {width:71px; height:71px; background-position: -304px -147px}
-      .shield:hover {width:71px; height:71px; background-position: -367px -1px}
-      .shine {width:53px; height:39px; background-position: -53px -180px}
-      .sign_boss {width:30px; height:30px; background-position: -108px -180px}
-      .sign_box {width:47px; height:47px; background-position: -377px -133px}
-      .sign_mission {width:30px; height:30px; background-position: -140px -180px}
-    STRING
+    content = 'fake_content'
 
     @packer = TexturePacker.new('side_menu_ocean', output_paths_mapping, content, false)
   end
@@ -53,10 +19,10 @@ class CopyToProjectTest < Minitest::Test
     FileUtils.expects(:mkdir_p).with(css_dir_path)
     FileUtils.expects(:mkdir_p).with(img_dir_path)
 
-    @cli.expects(:write_to_file).with(css_dir_path.join('mixin.scss'), 'content1')
-    @cli.expects(:write_to_file).with(css_dir_path.join('ocean.scss'), "@import './mixin.scss';\n\ncontent2")
+    @cli.expects(:write_to_file).with(css_dir_path.join('mixin.scss'), 'fake_content1')
+    @cli.expects(:write_to_file).with(css_dir_path.join('ocean.scss'), "@import './mixin.scss';\n\nfake_content2")
     FileUtils.expects(:cp).with('packed-fs8.png', img_dir_path.join('side_menu_ocean.png'))
 
-    @cli.send(:write_to_project_dir, @packer, 'content1', 'content2', false)
+    @cli.send(:write_to_project_dir, @packer, 'fake_content1', 'fake_content2', false)
   end
 end

--- a/test/copy_to_project_test.rb
+++ b/test/copy_to_project_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CopyToProjectTest < Minitest::Test
+  def setup
+    @cli = TexturePacker::Cli.new(['-p', '/var/www/my_project'])
+
+    output_paths_mapping = { nil => 'packed' }
+    content = <<~STRING
+      /* ----------------------------------------------------
+         created with http://www.codeandweb.com/texturepacker 
+         ----------------------------------------------------
+         $TexturePacker:SmartUpdate:0e3cde37abc2d6283d832d64fcab33a3:c1d35c5361d7a9ec65c17d37456c5ef2:020bd24e3165ccf6122edbac54bb505b$
+         ----------------------------------------------------
+      
+         usage: <span class="{-spritename-} sprite"></span>
+      
+         replace {-spritename-} with the sprite you like to use
+      
+      */
+      
+      .sprite {display:inline-block; overflow:hidden; background-repeat: no-repeat;background-image:url(packed.png);}
+      
+      .arrow-in {width:50px; height:98px; background-position: -1px -101px}
+      .arrow-out {width:51px; height:98px; background-position: -1px -1px}
+      .frame {width:73px; height:74px; background-position: -147px -80px}
+      .icon_boss {width:71px; height:71px; background-position: -221px -1px}
+      .icon_boss:hover {width:71px; height:71px; background-position: -148px -1px}
+      .icon_contents {width:71px; height:71px; background-position: -294px -1px}
+      .icon_contents:hover {width:71px; height:71px; background-position: -222px -74px}
+      .icon_craft {width:57px; height:57px; background-position: -377px -74px}
+      .icon_craft:hover {width:57px; height:57px; background-position: -172px -156px}
+      .icon_mission {width:71px; height:71px; background-position: -295px -74px}
+      .icon_mission:hover {width:71px; height:71px; background-position: -231px -147px}
+      .panel_bottom {width:92px; height:77px; background-position: -53px -101px}
+      .panel_top {width:92px; height:77px; background-position: -54px -1px}
+      .shield {width:71px; height:71px; background-position: -304px -147px}
+      .shield:hover {width:71px; height:71px; background-position: -367px -1px}
+      .shine {width:53px; height:39px; background-position: -53px -180px}
+      .sign_boss {width:30px; height:30px; background-position: -108px -180px}
+      .sign_box {width:47px; height:47px; background-position: -377px -133px}
+      .sign_mission {width:30px; height:30px; background-position: -140px -180px}
+    STRING
+
+    @packer = TexturePacker.new('side_menu_ocean', output_paths_mapping, content, false)
+  end
+
+  def test_save
+    expect_to_receive(FileUtils, :mkdir_p, 'sdf', nil) do
+      @cli.send(:write_to_project_dir, @packer, false)
+    end
+  end
+end

--- a/test/copy_to_project_test.rb
+++ b/test/copy_to_project_test.rb
@@ -23,6 +23,6 @@ class CopyToProjectTest < Minitest::Test
     @cli.expects(:write_to_file).with(css_dir_path.join('ocean.scss'), "@import './mixin.scss';\n\nfake_content2")
     FileUtils.expects(:cp).with('packed-fs8.png', img_dir_path.join('side_menu_ocean.png'))
 
-    @cli.send(:write_to_project_dir, @packer, 'fake_content1', 'fake_content2', false)
+    @cli.send(:write_to_project_dir!, @packer, 'fake_content1', 'fake_content2')
   end
 end

--- a/test/copy_to_project_test.rb
+++ b/test/copy_to_project_test.rb
@@ -12,17 +12,34 @@ class CopyToProjectTest < Minitest::Test
     @packer = TexturePacker.new('side_menu_ocean', output_paths_mapping, content, false)
   end
 
-  def test_save
+  def test_run_with_project_path
+    @cli.expects(:pack_css!)
+    @cli.expects(:create_packer).returns(@packer)
+    @packer.expects(:parse!).returns(['fake_output1', 'fake_output2', 'fake_output3'])
+    @cli.expects(:compress_images!)
+    @cli.expects(:write_to_file).with('packed.scss', 'fake_output1fake_output2fake_output3')
+
+    mock_write_to_project_dir
+
+    @cli.run
+  end
+
+  def test_write_to_project_dir_method
+    mock_write_to_project_dir
+    @cli.send(:write_to_project_dir!, @packer, 'fake_output2', 'fake_output3')
+  end
+
+  private
+
+  def mock_write_to_project_dir
     css_dir_path = Pathname.new('/var/www/my_project/app/assets/stylesheets/packed_sprites/side_menu')
     img_dir_path = Pathname.new('/var/www/my_project/app/assets/images')
 
     FileUtils.expects(:mkdir_p).with(css_dir_path)
     FileUtils.expects(:mkdir_p).with(img_dir_path)
 
-    @cli.expects(:write_to_file).with(css_dir_path.join('mixin.scss'), 'fake_content1')
-    @cli.expects(:write_to_file).with(css_dir_path.join('ocean.scss'), "@import './mixin.scss';\n\nfake_content2")
+    @cli.expects(:write_to_file).with(css_dir_path.join('mixin.scss'), 'fake_output2')
+    @cli.expects(:write_to_file).with(css_dir_path.join('ocean.scss'), "@import './mixin.scss';\n\nfake_output3")
     FileUtils.expects(:cp).with('packed-fs8.png', img_dir_path.join('side_menu_ocean.png'))
-
-    @cli.send(:write_to_project_dir!, @packer, 'fake_content1', 'fake_content2')
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,3 +6,9 @@ require 'texture_packer'
 
 require 'minitest/autorun'
 
+def expect_to_receive(obj, method, expected_args, return_value, &block)
+  obj.stub(method, proc{|args|
+    assert_equal(expected_args, args)
+    next return_value
+  }, &block)
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,10 +5,4 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'texture_packer'
 
 require 'minitest/autorun'
-
-def expect_to_receive(obj, method, expected_args, return_value, &block)
-  obj.stub(method, proc{|args|
-    assert_equal(expected_args, args)
-    next return_value
-  }, &block)
-end
+require 'mocha/minitest'

--- a/texture_packer.gemspec
+++ b/texture_packer.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.17', '< 3.x'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'mocha', '~> 1.11.2'
 end


### PR DESCRIPTION
## Usage

It will copied the generated files into your project after it is packed.
```rb
pack_scss -p /your/rails/project/path
pack_scss --project_dir=/your/rails/project/path
```

---
之前包成 gem 之後，那個 setting.yml 就失效了
只好包成參數

壞掉的原因應該是因為它會去讀當前路徑下的 setting.yml，但因為我們每個圖檔都在不同路徑下，所以讀不到。而原本可以是因為 rb 檔跟 setting.yml 放在同一層中，所以吃得到。


