### PR TITLE
Fix: the return value of Dir#[] method is different in different environments.

### DIFF
--- a/lib/texture_packer/cli.rb
+++ b/lib/texture_packer/cli.rb
@@ -53,7 +53,7 @@ class TexturePacker::Cli
 
   def output_paths_mapping
     @output_paths_mapping ||= begin
-      Dir['*.css'].map do |path|
+      Dir['*.css'].sort.map do |path|
         name = File.basename(path, '.css')
         next [name[/packed_(.*)/, 1], name]
       end.to_h


### PR DESCRIPTION
macOS 10.13.6
```rb
Dir['*.css']
# => ["packed_m.css", "packed.css"] 
```

Windows 7
```rb
Dir['*.css']
# => ["packed.css", "packed_m.css"] 
```