### PR TITLE
Fix: cannot split image by i18n due to a typo

### DIFF
--- a/lib/texture_packer/cli.rb
+++ b/lib/texture_packer/cli.rb
@@ -37,18 +37,20 @@ class TexturePacker::Cli
     end
   end
 
-  def create_packer
-    split_type = case
-                 when File.exist?('packed_tw_m.css') ; TexturePacker::SPLIT_BY_I18N_AND_MOBILE
-                 when File.exist?('packed_m.css')    ; TexturePacker::SPLIT_BY_MOBILE
-                 when File.exist?('packed_tw.css')   ; TexturePacker::SPLIT_BY_I18N
-                 end
+  def calculate_split_type
+    case
+    when File.exist?('packed_tw_m.css') ; return TexturePacker::SPLIT_BY_I18N_AND_MOBILE
+    when File.exist?('packed_m.css')    ; return TexturePacker::SPLIT_BY_MOBILE
+    when File.exist?('packed_tw.css')   ; return TexturePacker::SPLIT_BY_I18N
+    end
+  end
 
+  def create_packer
     # 由路徑計算 class 名字
     dir_name = File.expand_path(Dir.pwd).gsub(%r{.*/Texture-Packer/.*?/(.*)}, '\1')
 
     content = output_paths_mapping.map{|_, path| File.read("#{path}.css") }.join
-    return TexturePacker.new(dir_name, output_paths_mapping, content, split_type)
+    return TexturePacker.new(dir_name, output_paths_mapping, content, calculate_split_type)
   end
 
   def output_paths_mapping

--- a/lib/texture_packer/cli.rb
+++ b/lib/texture_packer/cli.rb
@@ -41,7 +41,7 @@ class TexturePacker::Cli
     split_type = case
                  when File.exist?('packed_tw_m.css') ; TexturePacker::SPLIT_BY_I18N_AND_MOBILE
                  when File.exist?('packed_m.css')    ; TexturePacker::SPLIT_BY_MOBILE
-                 when File.exist?('packed_tw.css')   ; TexturePacker::SPLIT_I18N
+                 when File.exist?('packed_tw.css')   ; TexturePacker::SPLIT_BY_I18N
                  end
 
     # 由路徑計算 class 名字

--- a/test/split_type_test.rb
+++ b/test/split_type_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SplitTypeTest < Minitest::Test
+  def setup
+    @cli = TexturePacker::Cli.new(['-p', '/var/www/my_project'])
+  end
+
+  def test_i18n_and_mobile
+    File.expects(:exist?).with('packed_tw_m.css').returns(true)
+    assert_equal 'i18n_and_mobile', @cli.send(:calculate_split_type)
+  end
+
+  def test_mobile
+    File.expects(:exist?).with('packed_tw_m.css').returns(false)
+    File.expects(:exist?).with('packed_m.css').returns(true)
+    assert_equal 'mobile', @cli.send(:calculate_split_type)
+  end
+
+  def test_i18n
+    File.expects(:exist?).with('packed_tw_m.css').returns(false)
+    File.expects(:exist?).with('packed_m.css').returns(false)
+    File.expects(:exist?).with('packed_tw.css').returns(true)
+    assert_equal 'i18n', @cli.send(:calculate_split_type)
+  end
+
+  def test_unknown
+    File.expects(:exist?).with('packed_tw_m.css').returns(false)
+    File.expects(:exist?).with('packed_m.css').returns(false)
+    File.expects(:exist?).with('packed_tw.css').returns(false)
+    assert_nil @cli.send(:calculate_split_type)
+  end
+end


### PR DESCRIPTION
It was implemented wrongly in the beginning in #12